### PR TITLE
Se agrego script appcenter para procesar env vars

### DIFF
--- a/appcenter-pre-build.sh
+++ b/appcenter-pre-build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Creates an .env from ENV variables for use with react-native-config
+ENV_WHITELIST=${ENV_WHITELIST:-"^RN_"}
+set | egrep -e $ENV_WHITELIST | sed 's/^RN_//g' > .env


### PR DESCRIPTION
## What's new? 

- Se agregó un script de prebuild para procesar las variables de entorno. 
- Con el fin de mantener la intención las variables de entorno, se agregan con el prefijo **RN_** en la ventana de appcenter (El RN_  se elimina respectivamente en el .env final). 

## Referencias 

[Link del artículo de Medium](https://blog.usejournal.com/react-native-config-and-appcenter-environment-variables-a1a3492ca6a0)